### PR TITLE
Fixed quotation mark error

### DIFF
--- a/abuse/abuse_en.csv
+++ b/abuse/abuse_en.csv
@@ -238,7 +238,7 @@ mcfagget
 mick
 minge
 mothafucka
-mothafuckin\'
+mothafuckin'
 motherfucker
 motherfucking
 muff


### PR DESCRIPTION
"mothafuckin'" had an unecessary backslash before the qutation mark, which caused an error when printing it out.